### PR TITLE
Update TinyGL 1.2 coverage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Unit tests cover common OpenGL calls, BGR uploads, draw range/element helpers, a
 - Optional lock-step worker thread controlled by `TINYGL_ENABLE_THREADS`
 - KTX texture loader for loading compressed assets
 - Additional unit tests including a comprehensive GL feature check
-- Full OpenGL 1.2 core compliance
+- Partial OpenGL 1.2 core coverage. See `tinygl/GL12_FEATURES.md` for details
 
 ## License
 MIT. See `LICENSE` for details.

--- a/tinygl/README.md
+++ b/tinygl/README.md
@@ -134,7 +134,7 @@ OpenIMGUI standard demo:
 TinyGL 0.8 (c) 1997-2021 Fabrice Bellard, C-Chads, Gek (see License, it's free software)
 
 This is a maintained fork of TinyGL, by the C-Chads.
-It is a small, suckless Software-only **full** GL 1.2 implementation.
+It is a small, suckless software renderer implementing a subset of the OpenGL 1.2 core profile.
 
 The original project was by Fabrice Bellard. We have forked it.
 
@@ -209,7 +209,7 @@ boosts performance. Also, implemented GL_FEEDBACK.
 
 
 
-Note that this Softrast **is not GL 1.2 compliant** and does not constitute a complete GL implementation.
+Note that this Softrast is not fully GL 1.2 compliant and does not constitute a complete GL implementation.
 
 You *will* have to tweak your code to work with this library. That said, once you have, it will run anywhere that you can get
 C99. TinyGL has very few external dependencies.


### PR DESCRIPTION
## Summary
- clarify that only portions of OpenGL 1.2 are implemented
- reference `GL12_FEATURES.md` for the details

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cmake -S .. -B build` in tinygl
- `cmake --build build` in tinygl

------
https://chatgpt.com/codex/tasks/task_e_68509453c41083258446c5e414da1bfd