### PR TITLE
Add LVGL build option documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,25 @@ Lightweight CNC machine visualization library built around TinyGL. It loads mach
    - `-DTINYGL_BUILD_DEBUG=ON` builds an unoptimised TinyGL library
    - `-DTINYGL_ENABLE_THREADS=OFF` disables the helper worker thread
    - `-DTINYGL_NUM_THREADS=<n>` controls worker count
+   - `-DTINYGL_WITH_LVGL=ON` builds LVGL helpers including `tgl_to_lvgl()`
 
 The build produces `libcncvis.a` and several TinyGL demos under `build/`.
+
+## LVGL Integration
+
+Compile TinyGL with LVGL support enabled:
+
+```bash
+cmake -S cncvis -B build -DTINYGL_WITH_LVGL=ON
+cmake --build build
+```
+
+In your LVGL display driver's flush callback, call `tgl_to_lvgl()` after rendering
+to copy the TinyGL framebuffer into the LVGL draw buffer.  Link your application
+against the TinyGL library produced in `build/lib`.
+
+TinyGL's LVGL bridge works with 16‑bit RGB565 and 32‑bit ARGB8888 color buffers.
+Other formats are unsupported.
 
 ## Tests
 Run the suite with:


### PR DESCRIPTION
## Summary
- document `-DTINYGL_WITH_LVGL` option
- explain calling `tgl_to_lvgl()` from an LVGL flush callback
- note supported color depths

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_685099800a5c832599f4e875d40c991d